### PR TITLE
feat: Linux audio support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ c64-kitty: c64-kitty.c
 macos-audio: c64-kitty.c audio_macos.c
 	gcc -D USE_AUDIO -O2 -Wall -W c64-kitty.c audio_macos.c -o c64-kitty -g -ggdb -framework AudioToolbox -framework CoreFoundation
 
+linux-audio: c64-kitty.c audio_linux.c
+	gcc -D USE_AUDIO -O2 -Wall -W -lpulse -lpulse-simple c64-kitty.c audio_linux.c -o c64-kitty -g -ggdb
+
 clean:
 	rm -f c64-kitty

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ c64-kitty: c64-kitty.c
 macos-audio: c64-kitty.c audio_macos.c
 	gcc -D USE_AUDIO -O2 -Wall -W c64-kitty.c audio_macos.c -o c64-kitty -g -ggdb -framework AudioToolbox -framework CoreFoundation
 
-linux-audio: c64-kitty.c audio_linux.c
+linux-pulseaudio: c64-kitty.c audio_linux.c
 	gcc -D USE_AUDIO -O2 -Wall -W -lpulse -lpulse-simple c64-kitty.c audio_linux.c -o c64-kitty -g -ggdb
 
 clean:

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ The code is licensed under the BSD license.
 
 ## Building
 
-On Linux and other Unix-alike system, where we don't have support for audio (yet) use:
+On other Unix-alike system, where we don't have support for audio (yet) use:
 
     make
 
 Otherwise, if you are in MacOS, use the following to use the low level C Audio API provided by the operating system:
 
     make macos-audio
+
+If you are in Linux, you can use `pulseaudio`, via the `pulseaudio-dev` library
+
+    make linux-audio
+
+pulseaudio interface is very common on Linux and also work for newer distributions with PipeWire.
 
 ## Loading PRG / BIN files
 
@@ -29,6 +35,4 @@ For instance, try this:
 
 The *unbelievable* [demo by Linus Åkesson](https://linusakesson.net/scene/a-mind-is-born/), released under the license Creative Commons BY-NC-SA, so I hope it is fine to include it here since this is open source code (Otherwise, please, Linus, tell me!).
 
-It is highly recommended to run the demo with audio on (on Mac).
-
-If you want to implement equally minimal, no dependencies, audio support for Linux, please send a pull request: thank you.
+It is highly recommended to run the demo with audio on (on Mac and Linux).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Otherwise, if you are in MacOS, use the following to use the low level C Audio A
 
 If you are in Linux, you can use `pulseaudio`, via the `pulseaudio-dev` library
 
-    make linux-audio
+    make linux-pulseaudio
 
 pulseaudio interface is very common on Linux and also work for newer distributions with PipeWire.
 

--- a/audio_linux.c
+++ b/audio_linux.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include <pulse/pulseaudio.h>
+#include <pulse/simple.h>
+
+void *audio_init(void)
+{
+	int error = 0;
+
+	pa_simple *pa_connection = NULL;
+
+	pa_sample_spec sample_format = {
+		.format = PA_SAMPLE_FLOAT32,
+		.rate = 44100,
+		.channels = 1
+	};
+
+	/*
+	 * pa_connection holds the connection to the pulseaudio server
+	 * we're using the simple API provided by Pulseaudio, as referred
+	 * in:
+	 *    https://freedesktop.org/software/pulseaudio/doxygen/simple.html
+	 */
+	pa_connection = pa_simple_new(
+			NULL,				// Use the default server.
+			"c64 Emulator Kitty",
+			PA_STREAM_PLAYBACK,
+			NULL,				// Use the default device.
+			"c64 Stream",
+			&sample_format,
+			NULL,				// Use default channel map
+			NULL,				// Use default buffering attributes.
+			&error);
+	if (!pa_connection) {
+		return NULL;
+	}
+
+	return (void *)pa_connection;
+}
+
+/* This function receive samples from the emulator. It will
+ * simply reproduce the samles received using pa_simple_write()
+ *     https://freedesktop.org/software/pulseaudio/doxygen/simple_8h.htm
+ */
+void audio_from_emulator(const float *samples, int num_samples, void *user_data)
+{
+	int error = 0;
+	pa_simple *pa_connection = user_data;
+
+	error = pa_simple_write(
+				pa_connection,
+				samples,
+				num_samples * sizeof(float),
+				&error);
+
+	if (error < 0)
+		fprintf(stderr,
+				"Failed to write data to audio server: %s\n",
+				pa_strerror(error));
+}
+
+void audio_cleanup(void *user_data)
+{
+	pa_simple *pa_connection = user_data;
+	pa_simple_free(pa_connection);
+}

--- a/audio_macos.c
+++ b/audio_macos.c
@@ -112,3 +112,5 @@ void *audio_init(void) {
     }
     return (void*)state;
 }
+
+void audio_cleanup(void *user_data) { return };

--- a/c64-kitty.c
+++ b/c64-kitty.c
@@ -13,6 +13,7 @@
 #include <termios.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/time.h>
 #include <assert.h>
 
 #define CHIPS_IMPL

--- a/c64-kitty.c
+++ b/c64-kitty.c
@@ -225,6 +225,7 @@ cleanup:
 #ifdef USE_AUDIO
 void *audio_init(void);
 void audio_from_emulator(const float *samples, int num_samples, void *user_data);
+void audio_cleanup(void *user_data);
 #endif
 
 int main(int argc, char* argv[]) {
@@ -298,6 +299,9 @@ int main(int argc, char* argv[]) {
         }
     }
 
+#ifdef USE_AUDIO
+    audio_cleanup(audio_user_data);
+#endif
     // Cleanup
     free(fb);
     disable_raw_mode();


### PR DESCRIPTION
Hi!

This patch will add audio support also on Linux.

I think the nearest thing to MacOS's `<AudioToolbox.h>` is `<pulseaudio.h>`
Pulseaudio is very used in Linux desktop land, and also supported by modern audio managers like PipeWire.

Tested with the included "A Mind is Born".

This is using the simple API provided here: https://freedesktop.org/software/pulseaudio/doxygen/simple_8h

I'm not sure if this fits your description of minimal implementation, the alternative would be to directly use ALSA, which needs user intervention in setting up the audio devices, while this works ootb.
Feel free to close this if it does not fit your request.

Thanks for your work
L.