### PR TITLE
fix for syntax in audio_macos.c

### DIFF
--- a/audio_macos.c
+++ b/audio_macos.c
@@ -115,6 +115,6 @@ void *audio_init(void) {
 
 void audio_cleanup(void *user_data) {
     AudioState *state = (AudioState *)user_data;
-    AudioQueueStop(state.queue, true);
-    AudioQueueDispose(state.queue, true);
+    AudioQueueStop(state->queue, true);
+    AudioQueueDispose(state->queue, true);
 };


### PR DESCRIPTION
Replace dot with arrow for access to a pointed struct member